### PR TITLE
fix: Changes in function process_dataargs to support the current implementation

### DIFF
--- a/tests/utils/test_preprocessing_utils.py
+++ b/tests/utils/test_preprocessing_utils.py
@@ -19,6 +19,7 @@ from tests.data import (
 
 # Local
 from tuning.config import configs
+from tuning.data.setup_dataprocessor import process_dataargs
 from tuning.utils.preprocessing_utils import (
     combine_sequence,
     format_dataset,
@@ -444,6 +445,78 @@ def test_format_dataset(data_args):
 @pytest.mark.parametrize(
     "data_args",
     [
+        # single sequence JSON and response template
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_JSON,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_JSON,
+                dataset_text_field="output",
+                response_template="\n### Label:",
+            )
+        ),
+        # single sequence JSONL and response template
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_JSONL,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_JSONL,
+                dataset_text_field="output",
+                response_template="\n### Label:",
+            )
+        ),
+        # data formatter template with input/output JSON
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSON,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSON,
+                dataset_text_field="formatted_field",
+                data_formatter_template="### Text:{{input}} \n\n### Label: {{output}}",
+            )
+        ),
+        # data formatter template with input/output JSONL
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSONL,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSONL,
+                dataset_text_field="formatted_field",
+                data_formatter_template="### Text:{{input}} \n\n### Label: {{output}}",
+            )
+        ),
+        # input/output JSON with masking on input
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSON,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSON,
+            )
+        ),
+        # input/output JSONL with masking on input
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSONL,
+                validation_data_path=TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSONL,
+            )
+        ),
+    ],
+)
+def test_process_dataargs(data_args):
+    """Ensure that the train/eval data are properly formatted based on the data args / text field"""
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    train_set, eval_set, dataset_text_field = process_dataargs(
+        data_args, tokenizer, max_seq_length=1024
+    )
+    assert isinstance(train_set, Dataset)
+    assert isinstance(eval_set, Dataset)
+    if dataset_text_field is None:
+        column_names = set(["input_ids", "attention_mask", "labels"])
+        assert set(eval_set.column_names) == column_names
+        assert set(train_set.column_names) == column_names
+    else:
+        assert dataset_text_field in train_set.column_names
+        assert dataset_text_field in eval_set.column_names
+
+
+@pytest.mark.parametrize(
+    "data_args",
+    [
         # JSON pretokenized train and validation datasets
         (
             configs.DataArguments(
@@ -475,6 +548,49 @@ def test_format_dataset(data_args):
 def test_format_dataset_pretokenized(data_args):
     """Ensure that pretokenized datasets are loaded and returned as is"""
     train_set, eval_set, _ = format_dataset(data_args, None, max_seq_length=1024)
+    assert isinstance(train_set, Dataset)
+    if eval_set:
+        assert isinstance(eval_set, Dataset)
+
+    assert set(["input_ids", "labels"]).issubset(set(train_set.column_names))
+    if eval_set:
+        assert set(["input_ids", "labels"]).issubset(set(eval_set.column_names))
+
+
+@pytest.mark.parametrize(
+    "data_args",
+    [
+        # JSON pretokenized train and validation datasets
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSON,
+                validation_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSON,
+            )
+        ),
+        # JSONL pretokenized train and validation datasets
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSONL,
+                validation_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSONL,
+            )
+        ),
+        # JSON pretokenized train datasets
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSON,
+            )
+        ),
+        # JSONL pretokenized train datasets
+        (
+            configs.DataArguments(
+                training_data_path=TWITTER_COMPLAINTS_TOKENIZED_JSONL,
+            )
+        ),
+    ],
+)
+def test_process_dataargs_pretokenized(data_args):
+    """Ensure that pretokenized datasets are loaded and returned as is"""
+    train_set, eval_set, _ = process_dataargs(data_args, None, max_seq_length=1024)
     assert isinstance(train_set, Dataset)
     if eval_set:
         assert isinstance(eval_set, Dataset)

--- a/tuning/data/data_handlers.py
+++ b/tuning/data/data_handlers.py
@@ -38,8 +38,11 @@ def tokenize_and_apply_input_masking(
     # TODO: Eventually move the code here
     combined = combine_sequence(input, output, eos_token=tokenizer.eos_token)
 
-    tokenized_comb_seqs = tokenizer(combined, **tokenizer_kwargs)
-    tokenized_input = tokenizer(input, **tokenizer_kwargs)
+    fn_kwargs = tokenizer_kwargs.get("fn_kwargs", {})
+    tokenizer_inner_kwargs = fn_kwargs.get("tokenizer_kwargs", {})
+
+    tokenized_comb_seqs = tokenizer(combined, **tokenizer_inner_kwargs)
+    tokenized_input = tokenizer(input, **tokenizer_inner_kwargs)
 
     masked_labels = [-100] * len(
         tokenized_input.input_ids

--- a/tuning/data/data_processors.py
+++ b/tuning/data/data_processors.py
@@ -157,7 +157,7 @@ class HFBasedDataPreProcessor(DataPreProcessor):
 
                     kwargs["fn_kwargs"] = dict(kwargs["fn_kwargs"], **extra_kwargs)
 
-                    logging.info("Applying Handler : {data_handler} Args : {kwargs}")
+                    logging.info(f"Applying Handler : {data_handler} Args : {kwargs}")
 
                     raw_datasets = raw_datasets.map(handler, **kwargs)
 

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -118,7 +118,7 @@ def process_dataargs(
         kwargs = {
             "fn_kwargs": fn_kwargs,
             "batched": False,
-            "remove_columns": [JSON_INPUT_KEY, JSON_OUTPUT_KEY],
+            "remove_columns": "all",
         }
 
         handler = DataHandlerConfig(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

1- Adding unit test case for testing function `process_dataargs` with current way of tuning.
2- Changes to make the case of dataset with `input, output` key work with current way of tuning and make `test_process_dataargs_pretokenized` handler work.

### Related issue number

https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1428

### How to verify the PR

Run current way of tuning for multiple cases:
- Case with using dataset with `text and label` as a single sequence, using [this dataset](https://github.com/Abhishek-TAMU/fms-hf-tuning/blob/data_preprocessor_dushyant/tests/data/twitter_complaints_small.jsonl)

Command used:
```
python tuning/sft_trainer.py  \
--model_name_or_path Maykeye/TinyLLama-v0  \
--training_data_path tests/data/twitter_complaints_small.jsonl  \
--output_dir outputs/full-tuning  \
--num_train_epochs 5  \
--per_device_train_batch_size 2  \
--gradient_accumulation_steps 1  \
--learning_rate 1e-5  \
--response_template "\n### Label:"  \
--dataset_text_field "output" \
--use_flash_attn false \
--torch_dtype "float32"
```

- Case with `pre-tokenized dataset` using [this dataset](https://github.com/Abhishek-TAMU/fms-hf-tuning/blob/data_preprocessor_dushyant/tests/data/twitter_complaints_tokenized_with_maykeye_tinyllama_v0.jsonl).

Command used:
```
python tuning/sft_trainer.py  \
--model_name_or_path Maykeye/TinyLLama-v0  \
--training_data_path tests/data/twitter_complaints_tokenized_with_maykeye_tinyllama_v0.jsonl \
--output_dir outputs/full-tuning  \
--num_train_epochs 5  \
--per_device_train_batch_size 2  \
--gradient_accumulation_steps 1  \
--learning_rate 1e-5  \
--use_flash_attn false \
--torch_dtype "float32"
```

- Case with `input, output` key in dataset using [this dataset](https://github.com/Abhishek-TAMU/fms-hf-tuning/blob/data_preprocessor_dushyant/tests/data/twitter_complaints_input_output.jsonl)

Command used:
```
python tuning/sft_trainer.py  \
--model_name_or_path Maykeye/TinyLLama-v0  \
--training_data_path tests/data/twitter_complaints_input_output.jsonl  \
--output_dir outputs/full-tuning  \
--num_train_epochs 5  \
--per_device_train_batch_size 2  \
--gradient_accumulation_steps 1  \
--learning_rate 1e-5  \
--use_flash_attn false \
--torch_dtype "float32"
```


### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass